### PR TITLE
Fixed typos

### DIFF
--- a/lib/rx.jquery.js
+++ b/lib/rx.jquery.js
@@ -182,7 +182,7 @@
                 observer.onCompleted();			
             };
             parent.on(types, selector, data, handler);
-            return dispoableEmpty;
+            return disposableEmpty;
         });
     };
     proto.readyAsObservable = function() {
@@ -192,7 +192,7 @@
                 observer.onNext(eventObject);
             };
             parent.ready(handler);
-            return dispoableEmpty;
+            return disposableEmpty;
         });
     };
     proto.hideAsObservable = function(duration) {


### PR DESCRIPTION
Fixed two typos: dispoableEmpty -> disposableEmpty.
